### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -5,11 +5,11 @@ hidden_title: true
 ---
 
 <p align="center">
-  <a href="/stableatlas/">Home</a> • 
-  <a href="/about">About</a> • 
-  <a href="/projects">Projects</a> • 
-  <a href="/blog">Blog</a> • 
-  <a href="/contact">Contact</a>
+  <a href="{{ '/' | relative_url }}">Home</a> •
+  <a href="{{ '/about' | relative_url }}">About</a> •
+  <a href="{{ '/projects' | relative_url }}">Projects</a> •
+  <a href="{{ '/blog' | relative_url }}">Blog</a> •
+  <a href="{{ '/contact' | relative_url }}">Contact</a>
 </p>
 
 <h1 style="text-align: center;">StableAtlas</h1>
@@ -20,66 +20,8 @@ Within, detailed instructions are provided for the creation of an automated pipe
 
 Data
 
-The three cornerstones of AI are, hardware, alogorithms and data. This project seeks to expand on possible solutions to solving some of the challenges of  data. More focused on the data itself rather than the physical constraints of storage or serving of said data. 
+The three cornerstones of AI are hardware, algorithms and data. This project seeks to expand on possible solutions to solving some of the challenges of data, focusing on the data itself rather than the physical constraints of storage or serving of that data.
 
-This project is a high level approach to the tracking and generation of the data itself. By systematically classifying data and using said structure to find where there is abscense we are able to automatically generate where there is need. Thus creating highly efficient training datasets or supplying large datasets that may be missing fundamental aspects with the information needed to correct.
+This project is a high level approach to the tracking and generation of the data itself. By systematically classifying data and using said structure to find where there is absence we are able to automatically generate what is missing. This creates highly efficient training datasets or supplies large datasets that may lack fundamental aspects with the information needed to correct them.
 
 By tracking this data we gain control of what is taught to AI models. In depth understanding of what goes in allows us fine tune and gain control over the outcomes of training.
-
-test
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-test

--- a/docs/stableconcept.markdown
+++ b/docs/stableconcept.markdown
@@ -11,13 +11,13 @@ hidden_title: true
 </h1>
 
 <p align="center">
-  <a href="/stableatlas/stableconcept">The Idea</a> • 
-  <a href="/about">Prototype</a> • 
-  <a href="/projects">Alpha</a> • 
-  <a href="/blog">Beta</a> • 
-  <a href="/contact">Release</a> •
-	<a href="/contact">Estimates</a> •
-	<a href="/contact">Challenges</a> •
+  <a href="{{ '/stableconcept' | relative_url }}">The Idea</a> •
+  <a href="{{ '/about' | relative_url }}">Prototype</a> •
+  <a href="{{ '/projects' | relative_url }}">Alpha</a> •
+  <a href="{{ '/blog' | relative_url }}">Beta</a> •
+  <a href="{{ '/contact' | relative_url }}">Release</a> •
+  <a href="{{ '/contact' | relative_url }}">Estimates</a> •
+  <a href="{{ '/contact' | relative_url }}">Challenges</a> •
 </p>
 
 

--- a/docs/stablehuman.markdown
+++ b/docs/stablehuman.markdown
@@ -5,71 +5,13 @@ hidden_title: true
 ---
 
 <p align="center">
-  <a href="/stableatlas/">Home</a> • 
-  <a href="/about">About</a> • 
-  <a href="/projects">Projects</a> • 
-  <a href="/blog">Blog</a> • 
-  <a href="/contact">Contact</a>
+  <a href="{{ '/' | relative_url }}">Home</a> •
+  <a href="{{ '/about' | relative_url }}">About</a> •
+  <a href="{{ '/projects' | relative_url }}">Projects</a> •
+  <a href="{{ '/blog' | relative_url }}">Blog</a> •
+  <a href="{{ '/contact' | relative_url }}">Contact</a>
 </p>
 
 <h1 style="text-align: center;">StableHuman</h1>
 
 StableHuman is a character authoring tool.
-
-test
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-test

--- a/docs/stableplayground.markdown
+++ b/docs/stableplayground.markdown
@@ -5,71 +5,13 @@ hidden_title: true
 ---
 
 <p align="center">
-  <a href="/stableatlas/">Home</a> • 
-  <a href="/about">About</a> • 
-  <a href="/projects">Projects</a> • 
-  <a href="/blog">Blog</a> • 
-  <a href="/contact">Contact</a>
+  <a href="{{ '/' | relative_url }}">Home</a> •
+  <a href="{{ '/about' | relative_url }}">About</a> •
+  <a href="{{ '/projects' | relative_url }}">Projects</a> •
+  <a href="{{ '/blog' | relative_url }}">Blog</a> •
+  <a href="{{ '/contact' | relative_url }}">Contact</a>
 </p>
 
 <h1 style="text-align: center;">StablePlayground</h1>
 
 StablePlayground is an engine.
-
-test
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-test


### PR DESCRIPTION
## Summary
- fix navigation paths to honor Jekyll `baseurl`
- correct typos and remove stray debug text

## Testing
- `bundle install --local`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_686817dfeabc832bbccdcf3a8ca127bc