### PR TITLE
Add page copy button

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -29,6 +29,10 @@
 
     <main class="page-content" aria-label="Content">
       <div class="wrapper">
+        <button id="copy-page-content-btn" class="util-btn" title="Copy Page Content for AI">
+          <span class="btn-icon">📄</span>
+          <span class="btn-text">Copy Page</span>
+        </button>
         {{ content }}
       </div>
     </main>
@@ -86,6 +90,58 @@
               btnText.innerText = originalText;
               copyBtn.classList.remove('copied', 'error', 'copying'); // Remove all state classes
               copyBtn.disabled = false;
+            }, 2000);
+          }
+        });
+      }
+    </script>
+
+    <!-- ======================================================= -->
+    <!--     JavaScript for the "Copy Page Content" Button        -->
+    <!-- ======================================================= -->
+    <script>
+      const pageCopyBtn = document.getElementById('copy-page-content-btn');
+
+      if (pageCopyBtn) {
+        const pageBtnText = pageCopyBtn.querySelector('.btn-text');
+        const pageOriginalText = pageBtnText.innerText;
+
+        pageCopyBtn.addEventListener('click', async () => {
+          if (pageCopyBtn.disabled) return;
+
+          pageBtnText.innerText = 'Copying...';
+          pageCopyBtn.classList.add('copying');
+          pageCopyBtn.disabled = true;
+
+          try {
+            const mainEl = document.querySelector('main.page-content');
+            if (!mainEl) throw new Error('Main content not found');
+
+            const clone = mainEl.cloneNode(true);
+            const btnInClone = clone.querySelector('#copy-page-content-btn');
+            if (btnInClone) btnInClone.remove();
+
+            const text = clone.innerText.trim();
+            if (!text) {
+              alert('Sorry, there is no content to copy on this page.');
+              throw new Error('Empty content');
+            }
+
+            await navigator.clipboard.writeText(text);
+
+            pageCopyBtn.classList.remove('copying');
+            pageCopyBtn.classList.add('copied');
+            pageBtnText.innerText = 'Copied!';
+          } catch (err) {
+            console.error('Failed to copy page content:', err);
+            pageCopyBtn.classList.remove('copying');
+            pageCopyBtn.classList.add('error');
+            pageBtnText.innerText = 'Error!';
+          } finally {
+            setTimeout(() => {
+              pageBtnText.innerText = pageOriginalText;
+              pageCopyBtn.classList.remove('copied', 'error', 'copying');
+              pageCopyBtn.disabled = false;
             }, 2000);
           }
         });

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -126,3 +126,50 @@ body {
     color: #f0b5bc;
     border-color: #6a2c31;
 }
+
+/* === Styles for the Page Copy Button === */
+#copy-page-content-btn {
+  margin-bottom: 1rem;
+}
+
+#copy-page-content-btn .btn-text {
+  display: none;
+  font-size: 0.9rem;
+  margin-left: 0.4em;
+}
+
+#copy-page-content-btn.copying .btn-icon,
+#copy-page-content-btn.copied .btn-icon,
+#copy-page-content-btn.error .btn-icon {
+  display: none;
+}
+
+#copy-page-content-btn.copying .btn-text,
+#copy-page-content-btn.copied .btn-text,
+#copy-page-content-btn.error .btn-text {
+  display: inline;
+}
+
+#copy-page-content-btn.copied {
+  background-color: #d4edda;
+  color: #155724;
+  border-color: #c3e6cb;
+}
+
+#copy-page-content-btn.error {
+  background-color: #f8d7da;
+  color: #721c24;
+  border-color: #f5c6cb;
+}
+
+[data-theme='dark'] #copy-page-content-btn.copied {
+    background-color: #1a3a24;
+    color: #a7d7b8;
+    border-color: #2a5a3a;
+}
+
+[data-theme='dark'] #copy-page-content-btn.error {
+    background-color: #4a1c21;
+    color: #f0b5bc;
+    border-color: #6a2c31;
+}


### PR DESCRIPTION
## Summary
- add a `Copy Page` button for quick page-level copy of content
- include JS logic to fetch the current page text and copy it
- style the new button with utility classes

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68705dd447a4832b8a1e742e7317b5ea